### PR TITLE
Download artifacts only in  root

### DIFF
--- a/downloads-artifacts.sh
+++ b/downloads-artifacts.sh
@@ -105,6 +105,7 @@ get_recursively () {
         --accept '*' \
         --random-wait \
         --no-host-directories \
+        --no-directories \
         --directory-prefix="$outdir" \
         --quiet --show-progress --progress=bar:force \
         "$url/";


### PR DESCRIPTION
The addition of "--no-directories" will ensures that wget will not create subdirectories based on the URL structure will instead download all files directly  (OUTDIR).

And now Should  all downloaded artifacts  being placed directly in the root of the ghaf-releases-artifacts folder without the nested subdirectories.  dont need to copy them to root!